### PR TITLE
fix(readme): point stats images to github-stats generated branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Contact me if you're looking for an SRE, Infrastructure Engineer or Cloud Engine
 
 ---
 
-![Michael Savin GitHub stats](https://github.com/jtprogru/github-stats/blob/master/generated/overview.svg)
-![Michael Savin GitHub stats](https://github.com/jtprogru/github-stats/blob/master/generated/languages.svg)
+![Mikhail Savin GitHub overview](https://github.com/jtprogru/github-stats/blob/generated/overview.svg#gh-dark-mode-only)
+![Mikhail Savin GitHub languages](https://github.com/jtprogru/github-stats/blob/generated/languages.svg#gh-dark-mode-only)
+![Mikhail Savin GitHub overview](https://github.com/jtprogru/github-stats/blob/generated/overview.svg#gh-light-mode-only)
+![Mikhail Savin GitHub languages](https://github.com/jtprogru/github-stats/blob/generated/languages.svg#gh-light-mode-only)
+
+![Mikhail Savin GitHub metrics](./github-metrics.svg)
 
 [myrucv]: https://savinmi.ru
 [myblog]: https://jtprog.ru


### PR DESCRIPTION
## Зачем

Обе картинки со статистикой в профиле отдавали 404. Апстрим `jstrieb/github-stats` в марте перенёс генерируемые файлы в отдельную ветку, а в апреле полностью переписал проект на Zig — папка `generated/` с ветки `master` исчезла, и ссылки вида `blob/master/generated/overview.svg` перестали резолвиться.

## Что изменилось

- Ссылки на `overview.svg` и `languages.svg` переведены на ветку `generated`, файлы теперь лежат в её корне.
- Добавлены фрагменты `#gh-dark-mode-only` / `#gh-light-mode-only`: в новых шаблонах корневой `<svg>` имеет `id="gh-dark-mode-only"`, а тёмная палитра включается через CSS-селектор `:target`. Без фрагмента картинка всегда рендерится в светлой теме.
- Добавлен `github-metrics.svg` — он уже обновляется воркфлоу `Metrics` каждые 30 минут, но в README не был подключён.

## Как проверить

Открыть превью README в светлой и тёмной теме GitHub. Картинки `github-stats` появятся после первого успешного прогона воркфлоу `Generate Stats Images` в `jtprogru/github-stats` — до этого ветки `generated` там нет. `github-metrics.svg` виден сразу.

## Риски

Нет, изменение только в README.