### PR TITLE
chore(ci): drop broken achievements plugin and dead metrics options

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,7 +1,7 @@
 # Visit https://github.com/lowlighter/metrics/blob/master/action.yml for full reference
 name: Metrics
 "on":
-  # Schedule updates (each hour)
+  # Schedule updates (every 30 minutes)
   schedule: [{cron: "*/30 * * * *"}]
   # Lines below let you run workflow manually and on each commit
   workflow_dispatch:
@@ -20,10 +20,9 @@ jobs:
           template: classic
           base: header, activity, community, repositories, metadata
           config_timezone: Europe/Moscow
-          plugin_achievements: yes
-          plugin_achievements_display: compact
-          plugin_achievements_secrets: yes
-          plugin_achievements_threshold: C
+          # plugin_achievements is disabled on purpose: its GraphQL query
+          # still asks for Projects (classic), which GitHub sunset, so the
+          # plugin always fails and renders "Unexpected error" into the SVG.
           plugin_gists: yes
           plugin_introduction: yes
           plugin_introduction_title: yes
@@ -31,9 +30,6 @@ jobs:
           plugin_languages_categories: markup, programming
           plugin_languages_colors: github
           plugin_languages_limit: 8
-          plugin_languages_recent_categories: markup, programming
-          plugin_languages_recent_days: 14
-          plugin_languages_recent_load: 300
           plugin_languages_sections: most-used
           plugin_languages_threshold: 0%
           plugin_lines: yes
@@ -41,6 +37,4 @@ jobs:
           plugin_people_limit: 24
           plugin_people_size: 28
           plugin_people_types: followers, following
-          plugin_repositories_affiliations: owner
-          plugin_repositories_forks: yes
           repositories_forks: yes


### PR DESCRIPTION
## Зачем

В `github-metrics.svg` в секции Achievements вместо ачивок рендерится блок «Unexpected error». В логах последнего прогона видно причину: запрос `AchievementsDefault` возвращает `Projects (classic) is being deprecated in favor of the new Projects experience`. Плагин обращается к Projects classic, которые GitHub закрыл, а последний релиз `lowlighter/metrics` — v3.34 от сентября 2023, так что само это не почините. Прогон при этом «зелёный», потому что `plugins_errors_fatal` по умолчанию выключен — ошибка просто впечатывается в картинку.

Заодно в конфиге накопились опции, которые ни на что не влияют.

## Что изменилось

- Убран `plugin_achievements` и три его опции, на месте оставлен комментарий с причиной.
- Убраны `plugin_languages_recent_categories`, `plugin_languages_recent_days`, `plugin_languages_recent_load` — они относятся к секции `recently-used`, а в `plugin_languages_sections` указан только `most-used`.
- Убраны `plugin_repositories_affiliations` и `plugin_repositories_forks` — без `plugin_repositories: yes` плагин repositories не включён. Глобальный `repositories_forks: yes` оставлен, он относится к базовой секции.
- Комментарий над `schedule` говорил «each hour» при `cron: "*/30 * * * *"`.

## Как проверить

После мержа воркфлоу отработает на push и перегенерирует `github-metrics.svg`. В новом файле не должно остаться `class="field error"`, а в логах прогона — блока `1 error(s) occurred`. Остальные секции (activity, community, languages, people, lines, gists) не затронуты.

## Риски

Секция Achievements пропадёт из картинки. Она и так не работала. Если захочется featured repositories — это отдельная правка, надо добавить `plugin_repositories: yes` и вернуть две опции.